### PR TITLE
Always use default branches for the repositories

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -39,7 +39,7 @@ jobs:
           git fetch sm7150 $DEFAULT_BRANCH
           git reset --hard sm7150/$DEFAULT_BRANCH
 
-      - name: check kernel branch
+      - name: Check kernel branch
         if: matrix.version == 'default'
         run: |
           DEFAULT_BRANCH=$(curl -s  https://api.github.com/repos/sm7150-mainline/linux | jq '.default_branch')

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -32,8 +32,9 @@ jobs:
           echo -e '\n\n' | pmbootstrap init || true
           cd ~/.local/var/pmbootstrap/cache_git/pmaports
           git remote add sm7150 https://github.com/sm7150-mainline/pmaports.git
-          git fetch sm7150 master
-          git reset --hard sm7150/master
+          DEFAULT_BRANCH=$(git remote show sm7150 | awk '/HEAD branch/ {print $NF}')
+          git fetch sm7150 $DEFAULT_BRANCH
+          git reset --hard sm7150/$DEFAULT_BRANCH
 
       - name: Clone kernel sources
         run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,11 +5,14 @@ on:
   schedule:
     - cron: '0 0 * * 5' # Run every friday at midnight
 
+env:
+  KERNEL_BRANCH: next
+
 jobs:
   build-image:
     strategy:
       matrix:
-        version: ["next", "v6.8.3"]
+        version: ["next", "default"]
 
     runs-on: ubuntu-latest
     steps:
@@ -36,9 +39,16 @@ jobs:
           git fetch sm7150 $DEFAULT_BRANCH
           git reset --hard sm7150/$DEFAULT_BRANCH
 
+      - name: check kernel branch
+        if: matrix.version == 'default'
+        run: |
+          DEFAULT_BRANCH=$(curl -s  https://api.github.com/repos/sm7150-mainline/linux | jq '.default_branch')
+          echo "Default branch is $DEFAULT_BRANCH"
+          echo "KERNEL_BRANCH=$DEFAULT_BRANCH" >> $GITHUB_ENV
+
       - name: Clone kernel sources
         run: |
-          git clone https://github.com/sm7150-mainline/linux.git --single-branch --branch ${{ matrix.version }} --depth 1
+          git clone https://github.com/sm7150-mainline/linux.git --single-branch --branch ${{ env.KERNEL_BRANCH }} --depth 1
 
       - name: Choose any SM7150 device in pmbootstrap to build kernel
         run: |


### PR DESCRIPTION
Always use default branches for the repositories(pmaports and kernel), by this builds will never fail and there will be no need for more pr in the future
(kernel repo will continue to use on default and next branch)